### PR TITLE
リクエストパラメータから任意のアタッチメントを適用できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # nenech
 This repo is Slack-Gateway
+dev_env: go1.13.8 darwin/amd64(macos)
 
 GateWay for Slack App by golang from JSON file
 
@@ -26,6 +27,8 @@ This GW adds a POST route to the web API based on this JSON file.
 You can send a message to slack by sending a POST request to the specified endpoint.
 
 ## Usage
+
+### Server side
 ```sh
 git clone https://github.com/silmin/nenech
 ```
@@ -35,3 +38,18 @@ move `./nenech`
 ```sh
 go run *.go
 ```
+
+### Client side
+```sh
+curl http://<your-server-addr>/<specified-endpoint>
+```
+The contents of the configuration file corresponding to the endpoint will be posted to Slack.
+
+
+In option,
+```sh
+curl http://<your-server-addr>/<specified-endpoint>\?username\=hoge
+```
+Username can be set to "hoge".
+
+You can set `username`/`title`/`message`/`color(good|warning|danger|(color code))`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nenech
 This repo is Slack-Gateway
-dev_env: go1.13.8 darwin/amd64(macos)
 
 GateWay for Slack App by golang from JSON file
+
+dev_env: go1.13.8 darwin/amd64(macos)
 
 ## About
 This GW does a POST for any Slack webhook-url on behalf of the host.

--- a/call_slack.go
+++ b/call_slack.go
@@ -7,19 +7,63 @@ import (
 	"github.com/labstack/echo"
 )
 
-type CallSlack struct {
-	Endpoint    string `json:"endpoint"`
-	Username    string `json:"username"`
-	Channel     string `json:"channel"`
-	Webhook_url string `json:"webhook_url"`
-	Title       string `json:"title"`
-	Message     string `json:"message"`
-	Color       string `json:"color"`
+type (
+	CallSlack struct {
+		Endpoint    string `json:"endpoint"`
+		Channel     string `json:"channel"`
+		Webhook_url string `json:"webhook_url"`
+
+		Username string `json:"username"`
+		Title    string `json:"title"`
+		Message  string `json:"message"`
+		Color    string `json:"color"`
+	}
+
+	CustomBinder struct{}
+)
+
+func (cb *CustomBinder) Bind(i *CallSlack, context echo.Context) error {
+	if param := context.QueryParam("username"); param != "" {
+		i.Username = param
+	}
+	if param := context.QueryParam("title"); param != "" {
+		i.Title = param
+	}
+	if param := context.QueryParam("message"); param != "" {
+		i.Message = param
+	}
+	if param := context.QueryParam("color"); param != "" {
+		i.Color = param
+	}
+	if param := context.FormValue("username"); param != "" {
+		i.Username = param
+	}
+	if param := context.FormValue("title"); param != "" {
+		i.Title = param
+	}
+	if param := context.FormValue("message"); param != "" {
+		i.Message = param
+	}
+	if param := context.FormValue("color"); param != "" {
+		i.Color = param
+	}
+	return nil
 }
 
 func (i CallSlack) Post(context echo.Context) error {
-	field := slack.Field{Title: i.Title, Value: i.Message}
+	cb := new(CustomBinder)
+	if err := cb.Bind(&i, context); err != nil {
+		return err
+	}
 
+	/*
+		log.Output(1, i.Username)
+		log.Output(1, i.Title)
+		log.Output(1, i.Message)
+		log.Output(1, i.Color)
+	*/
+
+	field := slack.Field{Title: i.Title, Value: i.Message}
 	attachment := slack.Attachment{}
 	attachment.AddField(field)
 	attachment.Color = &i.Color

--- a/configs/test.json
+++ b/configs/test.json
@@ -1,5 +1,5 @@
 {
-	"endpoint": "test",
+	"endpoint": "hoge",
 	"username": "nenech",
 	"channel": "test",
 	"webhook_url": "xxx",

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func getConfigs(dir string) ([]string, error) {
 
 func main() {
 	configs, err := getConfigs("./configs/")
-	fmt.Println(configs)
 	if err != nil {
 		log.Fatal(err)
 		return
@@ -58,8 +57,10 @@ func main() {
 		if err := json.Unmarshal(bytes, &call_slack); err != nil {
 			log.Fatal(err)
 		}
-		e.POST("/"+call_slack.Endpoint, call_slack.Post)
+		ep_tmp := "/%s"
+		endpoint := fmt.Sprintf(ep_tmp, call_slack.Endpoint)
+		e.GET(endpoint, call_slack.Post)
 
-		e.Start(":8000")
 	}
+	e.Start(":8000")
 }


### PR DESCRIPTION
## 追加(Add)
### 任意のアタッチメントを適用可能に(Applicable to any attachment)
リクエストパラメータによって，任意の `username`/`title`/`message`/`color`を適用可能に．  
configファイルはそのエンドポイントのデフォルトになる．

optional `username`/`title`/`message`/`color` by request param.  
config file to be default attachment in specified endpoint

## 修正(Fix)

## その他(Other)
readmeの更新

update readme file